### PR TITLE
Update GitHub Actions workflow to work with budibase releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,6 +6,7 @@ on:
       - master
       - main
 
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,7 @@ jobs:
 
       - uses: actions/checkout@v3
         with:
-          repository: poirazis/bb-component-SuperTableColumn
+          repository: nutgood/bb-component-SuperTableColumn
           ref: main
           path: bb-component-SuperTableColumn
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,7 @@ jobs:
 
       - uses: actions/checkout@v3
         with:
-          repository: nutgood/bb-component-SuperTableColumn
+          repository: poirazis/bb-component-SuperTableColumn
           ref: main
           path: bb-component-SuperTableColumn
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,7 +6,6 @@ on:
       - master
       - main
 
-
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -14,6 +13,8 @@ jobs:
       contents: write
     steps:
       - uses: actions/checkout@v3
+        with:
+          submodules: true
       - uses: actions/setup-node@v1
         with:
           node-version: 16

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,12 +14,26 @@ jobs:
     steps:
       - uses: actions/checkout@v3
         with:
-          submodules: true
+          path: bb-component-SuperTable
+
+      - uses: actions/checkout@v3
+        with:
+          repository: poirazis/bb-component-SuperTableColumn
+          ref: main
+          path: bb-component-SuperTableColumn
+
+      - uses: actions/checkout@v3
+        with:
+          repository: poirazis/bb-component-SuperTableCell
+          ref: main
+          path: bb-component-SuperTableCell
+
       - uses: actions/setup-node@v1
         with:
           node-version: 16
       - name: Make the production plugin bundle
         run: |
+          cd bb-component-SuperTable
           release_version=$(cat package.json | jq -r '.version')
           echo "RELEASE_VERSION=$release_version" >> $GITHUB_ENV
           yarn

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,7 @@
 [submodule "bb-component-SuperTableColumn"]
 	path = bb-component-SuperTableColumn
 	url = https://github.com/poirazis/bb-component-SuperTableColumn
+
+[submodule "bb-component-SuperTableColumn/bb-component-SuperTableCell"]
+	path = bb-component-SuperTableColumn/bb-component-SuperTableCell
+	url = https://github.com/poirazis/bb-component-SuperTableCell

--- a/.gitmodules
+++ b/.gitmodules
@@ -2,5 +2,6 @@
 	path = bb-component-SuperTableColumn
 	url = https://github.com/poirazis/bb-component-SuperTableColumn
 
-[submodule "bb-component-SuperTableColumn/bb-component-SuperTableCell"]
+[submodule "bb-component-SuperTableCell"]
+	path = bb-component-SuperTableColumn/bb-component-SuperTableCell
 	url = https://github.com/poirazis/bb-component-SuperTableCell

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,7 +1,3 @@
 [submodule "bb-component-SuperTableColumn"]
 	path = bb-component-SuperTableColumn
 	url = https://github.com/poirazis/bb-component-SuperTableColumn
-
-[submodule "bb-component-SuperTableCell"]
-	path = bb-component-SuperTableColumn/bb-component-SuperTableCell
-	url = https://github.com/poirazis/bb-component-SuperTableCell

--- a/.gitmodules
+++ b/.gitmodules
@@ -3,5 +3,4 @@
 	url = https://github.com/poirazis/bb-component-SuperTableColumn
 
 [submodule "bb-component-SuperTableColumn/bb-component-SuperTableCell"]
-	path = bb-component-SuperTableColumn/bb-component-SuperTableCell
 	url = https://github.com/poirazis/bb-component-SuperTableCell

--- a/lib/SuperTable/SuperTable.svelte
+++ b/lib/SuperTable/SuperTable.svelte
@@ -11,7 +11,7 @@
   import SuperTableRowSelect from "./controls/SuperTableRowSelect.svelte";
 
   // Imports from submodules
-  import { SuperTableColumn } from "../../bb-component-SuperTableColumn/lib/SuperTableColumn/index.js"
+  import { SuperTableColumn } from "../../../bb-component-SuperTableColumn/lib/SuperTableColumn/index.js"
   const { getAction, ActionTypes } = getContext("sdk");
 
   export let tableOptions


### PR DESCRIPTION
Hello !

I updated your github actions workflow so that it builds plugins releases by itself again.

I was unable to get the submodule approach working, so instead, I'm using parallel cloning.

Basically, instead of the tree being like this:
```
bb-component-SuperTable/
   bb-component-SuperTableColumn/
       bb-component-SuperTableCell/
```

It is like this:
```
github-actions/
    bb-component-SuperTable/
    bb-component-SuperTableColumn/
    bb-component-SuperTableCell/
```

I've had to update both the SuperTable and SuperTableColumn repoes so there is PRs in both of them, I would recommend merging the column one before you merge the table one.

Also the history is not particularly clean, but that is due to me trying out submodules and the fact that you can't test gihub actions workflows easily.

